### PR TITLE
Passing variables from url placeholders into response content template

### DIFF
--- a/features/tutu/create_response_with_values_from_url.feature
+++ b/features/tutu/create_response_with_values_from_url.feature
@@ -1,0 +1,23 @@
+Feature: Create response for specific body
+  As a api client developer
+  In order to simulate simple api behavior
+  I need to create be able to create different responses based on request body
+
+  Background:
+    Given TuTu is running on host "localhost" at port "8000"
+
+  Scenario: Create response that contains variables from url placeholder
+    When there is a responses config file "responses.yml" with following content:
+    """
+    request_with_variables_in_url:
+      request:
+        path: "/users/{email}/tasks/{taskId}"
+      response:
+        content: "Get task with ID {{path.taskId}} from user with email {{path.email}}"
+    """
+    And http client sends GET request on "http://localhost:8000/index.php/users/norbert@coduo.pl/tasks/1"
+    Then response status code should be 200
+    And the response content should be equal to:
+    """
+    Get task with ID 1 from user with email norbert@coduo.pl
+    """

--- a/spec/Coduo/TuTu/Request/Path/ParserSpec.php
+++ b/spec/Coduo/TuTu/Request/Path/ParserSpec.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace spec\Coduo\TuTu\Request\Path;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\Request;
+
+class ParserSpec extends ObjectBehavior
+{
+    function it_return_empty_array_when_there_are_no_placeholders_in_url()
+    {
+        $request = Request::create('/foo');
+        $this->extractPlaceholders($request, '/foo')->shouldReturn(array());
+    }
+
+    function it_return_values_when_there_are_placeholders_in_url()
+    {
+        $request = Request::create('/users/email@example.com/tasks/1');
+        $this->extractPlaceholders($request, '/users/{email}/tasks/{taskId}')->shouldReturn(array(
+            'email' => 'email@example.com',
+            'taskId' => '1'
+        ));
+    }
+
+    function it_return_empty_array_when_request_path_does_not_match_url_pattern()
+    {
+        $request = Request::create('/users/email@example.com');
+        $this->extractPlaceholders($request, '/users/{email}/tasks/{taskId}')->shouldReturn(array());
+    }
+}
+

--- a/src/Coduo/TuTu/Kernel.php
+++ b/src/Coduo/TuTu/Kernel.php
@@ -13,6 +13,7 @@ use Coduo\TuTu\Request\ChainMatchingPolicy;
 use Coduo\TuTu\Request\HeadersMatchingPolicy;
 use Coduo\TuTu\Request\MethodMatchingPolicy;
 use Coduo\TuTu\Request\ParameterMatchingPolicy;
+use Coduo\TuTu\Request\Path\Parser;
 use Coduo\TuTu\Request\RouteMatchingPolicy;
 use Coduo\TuTu\Response\Builder;
 use Symfony\Component\ClassLoader\ClassLoader;
@@ -206,8 +207,11 @@ class Kernel implements HttpKernelInterface
 
     private function registerResponseBuilder()
     {
+        $this->container->setDefinition('request.path.parser', function($container) {
+            return new Parser();
+        });
         $this->container->setDefinition('response.builder', function ($container) {
-            return new Builder($container->getService('twig'));
+            return new Builder($container->getService('twig'), $container->getService('request.path.parser'));
         });
     }
 

--- a/src/Coduo/TuTu/Request/BodyMatchingPolicy.php
+++ b/src/Coduo/TuTu/Request/BodyMatchingPolicy.php
@@ -14,6 +14,14 @@ class BodyMatchingPolicy implements MatchingPolicy
     private $phpMatcher;
 
     /**
+     * @param Matcher $phpMatcher
+     */
+    public function __construct(Matcher $phpMatcher)
+    {
+        $this->phpMatcher = $phpMatcher;
+    }
+
+    /**
      * @param Request $request
      * @param Element $config
      * @return boolean
@@ -29,10 +37,5 @@ class BodyMatchingPolicy implements MatchingPolicy
         }
 
         return true;
-    }
-
-    public function __construct(Matcher $phpMatcher)
-    {
-        $this->phpMatcher = $phpMatcher;
     }
 }

--- a/src/Coduo/TuTu/Request/Path/Parser.php
+++ b/src/Coduo/TuTu/Request/Path/Parser.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Coduo\TuTu\Request\Path;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class Parser
+{
+    public function extractPlaceholders(Request $request, $pathPattern)
+    {
+        preg_match_all('#\{\w+\}#', $pathPattern, $placeholders, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+
+        if (!count($placeholders)) {
+            return array();
+        }
+
+        $placeholderNames = array();
+        foreach ($placeholders as $placeholderMatch) {
+            $placeholder = $placeholderMatch[0][0];
+            $placeholderNames[] = substr($placeholder, 1, -1);
+            $pathPattern = str_replace($placeholder, '__PLACEHOLDER__', $pathPattern);
+        }
+
+        $pathPattern = '/^' . str_replace('__PLACEHOLDER__', '([^\/]*)', preg_quote($pathPattern, '/')) . '$/i';
+
+        if (0 === preg_match($pathPattern, $request->getPathInfo(), $matches)) {
+            return array();
+        }
+
+        return array_combine(
+            $placeholderNames,
+            array_slice($matches, 1, count($placeholders))
+        );
+    }
+}

--- a/src/Coduo/TuTu/Response/Builder.php
+++ b/src/Coduo/TuTu/Response/Builder.php
@@ -3,6 +3,7 @@
 namespace Coduo\TuTu\Response;
 
 use Coduo\TuTu\Config\Element;
+use Coduo\TuTu\Request\Path\Parser;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -13,9 +14,15 @@ class Builder
      */
     private $twig;
 
-    public function __construct(\Twig_Environment $twig)
+    /**
+     * @var \Coduo\TuTu\Request\Path\Parser
+     */
+    private $requestParser;
+
+    public function __construct(\Twig_Environment $twig, Parser $requestParser)
     {
         $this->twig = $twig;
+        $this->requestParser = $requestParser;
     }
 
     /**
@@ -26,7 +33,8 @@ class Builder
     public function build(Element $config, Request $request)
     {
         $content = $this->twig->render($config->getResponse()->getContent(), [
-            'request' => $request
+            'request' => $request,
+            'path' => $this->requestParser->extractPlaceholders($request, $config->getRequest()->getPath())
         ]);
 
         return new Response($content, $config->getResponse()->getStatus(), $config->getResponse()->getHeaders());


### PR DESCRIPTION
From now values under placeholders in url are going to be available in twig template under `path` variable. 
If there are no placehodlers `path` variable will be an empty array.

Simple example: 

```
# responses.yml
request_with_variables_in_request_path:
  request:
    path: "/users/{email}/tasks/{taskId}"
  response:
    content: "Get task with ID {{path.taskId}} from user with email {{path.email}}"
```

So now after http request on "/users/norbert@coduo.pl/tasks/1" TuTu will return following response:

```
Get task with ID 1 from user with email norbert@coduo.pl
```
